### PR TITLE
Change Polish language tag from en-us to pl

### DIFF
--- a/PolishTranslation/Relases/GameData/PolishTranslation/Localization.cfg
+++ b/PolishTranslation/Relases/GameData/PolishTranslation/Localization.cfg
@@ -1,6 +1,6 @@
 ﻿Localization
 {
-	en-us
+	pl
 	{
 		#autoLOC_18284 = Asystent Stabilności
 		#autoLOC_18285 = Utrzymywanie Prostej / Retrogradacji


### PR DESCRIPTION
Hi @MarcinZboralski,

While reviewing KSP-CKAN/NetKAN#9579, I noticed that the CKAN tools were adding this to the metadata:

```json
      "localizations": [
          "en-us"
      ],
```

This is retrieved from the `Localization` node in the cfg file. It means that you are setting the English language strings instead of Polish. I think this will be a problem because your plugin explicitly switches the language to `pl`:

https://github.com/MarcinZboralski/PolishTranslation/blob/23996749e29284ebaf73f5c1838d364a4cf0778c/PolishTranslation/Localization.cs#L17

Now the cfg's language tag is changed to `pl`.

Cheers!